### PR TITLE
Cleanup and simplified schema

### DIFF
--- a/src/dtos/registrations.dto.ts
+++ b/src/dtos/registrations.dto.ts
@@ -1,11 +1,10 @@
 import { IsEmail, IsString, IsNotEmpty, MinLength, MaxLength, IsEnum, IsOptional, IsArray } from 'class-validator'
 import { InputType, Field } from 'type-graphql'
-import { UserRole } from '@/interfaces/users.interface'
 import { Registration } from '@/interfaces/registrations.interface'
 
 
 @InputType()
-export class CreateRegistrationDto {
+export class CreateRegistrationDto implements Partial<Registration> {
   @Field()
   @IsNotEmpty()
   @IsEmail()
@@ -53,57 +52,3 @@ export class CreateRegistrationDto {
   heardAboutUs?: string;
 }
 
-@InputType()
-export class CreateUserDto implements Partial<Registration> {
-  @Field()
-  @IsEmail()
-  email: string
-
-  @Field()
-  @IsString()
-  firstName: string
-
-  @Field()
-  @IsString()
-  lastName: string
-
-  @Field(() => UserRole, {nullable: true} )
-  @IsEnum(UserRole, { message: 'Role must be admin, teacher, or student' })
-  role: UserRole
-}
-
-// @InputType()
-// export class UpdateUserDto implements Partial<Registration> {
-//   @Field({ nullable: true })
-//   @IsString()
-//   @IsNotEmpty()
-//   @MinLength(9)
-//   @MaxLength(32)
-//   password: string
-
-//   @Field({ nullable: true })
-//   @IsString()
-//   firstName: string
-
-//   @Field({ nullable: true })
-//   @IsString()
-//   lastName: string
-
-//   @Field(() => UserRole, {nullable: true} )
-//   @IsEnum(UserRole, { message: 'Role must be admin, teacher, or student' })
-//   role: UserRole
-// }
-
-@InputType()
-export class LoginUserDto implements Partial<Registration> {
-  @Field()
-  @IsEmail()
-  email: string
-
-  @Field()
-  @IsString()
-  @IsNotEmpty()
-  @MinLength(9)
-  @MaxLength(32)
-  password: string
-}

--- a/src/dtos/users.dto.ts
+++ b/src/dtos/users.dto.ts
@@ -1,7 +1,6 @@
 import { IsEmail, IsString, IsNotEmpty, MinLength, MaxLength, IsEnum } from 'class-validator'
 import { InputType, Field } from 'type-graphql'
 import { User } from '@typedefs/users.type'
-import { UserRole } from '@/interfaces/users.interface'
 
 @InputType()
 export class CreateUserDto implements Partial<User> {
@@ -24,9 +23,9 @@ export class CreateUserDto implements Partial<User> {
   @IsString()
   lastName: string
 
-  @Field(() => UserRole, {nullable: true} )
-  @IsEnum(UserRole, { message: 'Role must be admin, teacher, or student' })
-  role: UserRole
+  @Field({ nullable: true })
+  @IsString()
+  role: string
 }
 
 @InputType()
@@ -46,9 +45,9 @@ export class UpdateUserDto implements Partial<User> {
   @IsString()
   lastName: string
 
-  @Field(() => UserRole, {nullable: true} )
-  @IsEnum(UserRole, { message: 'Role must be admin, teacher, or student' })
-  role: UserRole
+  @Field({ nullable: true })
+  @IsString()
+  role: string
 }
 
 @InputType()

--- a/src/entities/batches.entity.ts
+++ b/src/entities/batches.entity.ts
@@ -2,14 +2,13 @@ import { BaseEntity, Entity, OneToMany, PrimaryColumn } from 'typeorm'
 import { Batch, BatchSession } from '@/interfaces/batches.interface'
 import { UserEntity } from './users.entity'
 
-const batchYear = new Date().toLocaleDateString('en', { year: '2-digit' })
+// const batchYear = new Date().toLocaleDateString('en', { year: '2-digit' })
 // const batchDateSpring = `${BatchSession.BATCH_SPRING}-${batchYear}`
-const batchDateFall = `${BatchSession.BATCH_FALL}-${batchYear}`
+// const batchDateFall = `${BatchSession.BATCH_FALL}-${batchYear}`
 
 @Entity()
 export class BatchEntity extends BaseEntity implements Batch {
   @PrimaryColumn({
-    default: batchDateFall,
     unique: true
   })
   batchId: string

--- a/src/entities/courses.entity.ts
+++ b/src/entities/courses.entity.ts
@@ -5,7 +5,10 @@ import { EnrollmentEntity } from './enrollment.entity'
 
 @Entity()
 export class CourseEntity extends BaseEntity implements Course {
-  @PrimaryColumn({ unique: true })
+  @PrimaryGeneratedColumn('uuid')
+  id: number
+
+  @Column({ unique: true })
   code: string
 
   @Column()

--- a/src/entities/registrations.entity.ts
+++ b/src/entities/registrations.entity.ts
@@ -1,7 +1,6 @@
 import { IsNotEmpty } from 'class-validator'
 import { BaseEntity, Entity, PrimaryGeneratedColumn, Column, Unique, CreateDateColumn, UpdateDateColumn, OneToMany, ManyToOne, JoinColumn } from 'typeorm'
 import { Registration } from '@/interfaces/registrations.interface'
-// import { CourseMode } from '@/interfaces/courses.interface'
 
 @Entity()
 export class RegistrationEntity extends BaseEntity implements Registration {
@@ -15,8 +14,8 @@ export class RegistrationEntity extends BaseEntity implements Registration {
   @Column()
   name: string
 
-  // @Column()
-  // age: Date
+  @Column()
+  age: string
   
   @Column()
   phone: string
@@ -38,13 +37,6 @@ export class RegistrationEntity extends BaseEntity implements Registration {
 
   @Column({ nullable: true })
   trainingMode: string
-
-  // @Column({
-  //   type: 'enum',
-  //   enum: CourseMode,
-  //   nullable: true
-  // })
-  // trainingMode: CourseMode
 
   @Column('simple-array', { nullable: true })
   courses: string[]

--- a/src/entities/users.entity.ts
+++ b/src/entities/users.entity.ts
@@ -4,7 +4,6 @@ import { User, UserRole } from '@interfaces/users.interface'
 import { EnrollmentEntity } from './enrollment.entity'
 import { SubmissionEntity } from './submissions.entity'
 import { BatchEntity } from './batches.entity'
-// import { CourseMode } from '@/interfaces/courses.interface'
 
 @Entity()
 export class UserEntity extends BaseEntity implements User {
@@ -24,25 +23,14 @@ export class UserEntity extends BaseEntity implements User {
   @Column({ nullable: true })
   phone: string
   
-  @Column({
-    type: 'enum',
-    enum: UserRole,
-    default: UserRole.STUDENT,
-  })
-  role: UserRole
+  @Column({ default: UserRole.STUDENT })
+  role: string
 
   @Column()
   password: string
 
   @Column({ nullable: true })
   trainingMode: string
-
-  // @Column({
-  //   type: 'enum',
-  //   enum: CourseMode,
-  //   nullable: true
-  // })
-  // trainingMode: CourseMode
 
   @Column()
   @CreateDateColumn()

--- a/src/interfaces/common/index.ts
+++ b/src/interfaces/common/index.ts
@@ -5,3 +5,10 @@ export interface MyContext {
     res: Response
     user?: any
   }
+
+  
+export enum TrainingMode {
+  ONLINE = 'Online',
+  LAHORE_CAMPUS = 'Lahore Campus',
+  ISLAMABAD_CAMPUS = 'Islamabad Campus',
+}

--- a/src/interfaces/courses.interface.ts
+++ b/src/interfaces/courses.interface.ts
@@ -1,8 +1,5 @@
-import { registerEnumType } from "type-graphql"
-
 export interface Course {
   title: string
   code: string
   description: string
 }
-

--- a/src/interfaces/registrations.interface.ts
+++ b/src/interfaces/registrations.interface.ts
@@ -14,15 +14,3 @@ export interface Registration {
   heardAboutUs?: string
 }
 
-
-// export enum CourseMode {
-//   ONLINE = 'Online',
-//   LAHORE_CAMPUS = 'Lahore Campus',
-//   ISLAMABAD_CAMPUS = 'Islamabad Campus',
-// }
-
-
-// registerEnumType(CourseMode, {
-//   name: "CourseMode",
-//   description: "Mode of training.", 
-// })

--- a/src/interfaces/users.interface.ts
+++ b/src/interfaces/users.interface.ts
@@ -1,4 +1,3 @@
-import { registerEnumType } from "type-graphql";
 
 export interface User {
   id: string
@@ -18,8 +17,3 @@ export enum UserRole {
   TEACHER = 'Teacher',
   ADMIN = 'Admin',
 }
-
-registerEnumType(UserRole, {
-  name: "UserRole",
-  description: "The allowed roles for a user", 
-})

--- a/src/typedefs/registration.type.ts
+++ b/src/typedefs/registration.type.ts
@@ -1,5 +1,4 @@
 import { Field, ObjectType } from 'type-graphql'
-// import { CourseMode } from '@/interfaces/courses.interface'
 
 @ObjectType()
 export class Registration {

--- a/src/typedefs/users.type.ts
+++ b/src/typedefs/users.type.ts
@@ -1,4 +1,3 @@
-import { UserRole } from '@/interfaces/users.interface'
 import { Field, ObjectType } from 'type-graphql'
 
 @ObjectType()
@@ -12,7 +11,7 @@ export class User {
   @Field({ nullable: true })
   name?: string
 
-  @Field(() => UserRole, { nullable: true })
-  role?: UserRole
+  @Field({ nullable: true })
+  role?: string
 
 }


### PR DESCRIPTION
Simplifying schema typing by removing enums, we will want to use the enums as we save during mutation operations. I think this will be simpler to manage than defining enums on a schema level.